### PR TITLE
Fix how ShouldSyncOnReimportedAsset determines path

### DIFF
--- a/Scripts/ProjectGeneration.cs
+++ b/Scripts/ProjectGeneration.cs
@@ -182,7 +182,7 @@ namespace VSCodePackage
 
         static bool ShouldSyncOnReimportedAsset(string asset)
         {
-            return k_ReimportSyncExtensions.Contains(new FileInfo(asset).Extension);
+            return k_ReimportSyncExtensions.Contains(Path.GetExtension(asset));
         }
 
         public void Sync()


### PR DESCRIPTION
There is an issue when you change the AssetDatabase in Editor Player Awake which results in ShouldSyncOnReimportedAsset not working properly as it was.

Same issue identified in Resharper some time ago: https://github.com/JetBrains/resharper-unity/issues/1524

Basically when entering playmode, if an editor script modifies a scriptable object and then calls AssetDatabase.SaveAssets(); you can reproduce this issue 100% of the time.