### PR TITLE
Do not hide .gitignore

### DIFF
--- a/Scripts/ProjectGeneration.cs
+++ b/Scripts/ProjectGeneration.cs
@@ -37,7 +37,6 @@ namespace VSCodePackage
     {
         ""**/.DS_Store"":true,
         ""**/.git"":true,
-        ""**/.gitignore"":true,
         ""**/.gitmodules"":true,
         ""**/*.booproj"":true,
         ""**/*.pidb"":true,


### PR DESCRIPTION
**The problem:**

When generating project files for Visual Studio Code, this package will create a local `settings.json` that adds a lengthy `files.exclude` definition, hiding a whole bunch of files from the editor. I suppose that the idea here is that the user should mostly just see his _code_ files in VS Code and not be bothered by binary assets and similar, but feel that hiding a critical and often-edited file like `.gitignore` is a mistake.

**The reasoning:**

Hiding `.gitignore` will not only hide the file from the explorer side bar, but also from VS Code's fuzzy search. Basically, the only way to open this file is to open a terminal and run `code .gitignore`. That's not terribly great, and I always just end up manually adjusting this file in every project. I feel that this package simply shouldn't hide this file to begin with.

**The proposed solution:**

This very simple Pull Request simply removes `.gitignore` from the list of hidden files.

_(I would make a similar argument about `.gitmodules`, but I want to keep this pull request focused on just `.gitignore`.)_

**Complementary late-2000s meme for your enjoyment:**

![image](https://user-images.githubusercontent.com/1061/90332036-ad708e00-dfb9-11ea-98a0-ac76899a48a0.png)

Tell David I love him.